### PR TITLE
Split monoid / semigroup instance for recent GHC

### DIFF
--- a/src/Text/Dot/Types/Internal.hs
+++ b/src/Text/Dot/Types/Internal.hs
@@ -74,19 +74,19 @@ data Dot = Node NodeId [Attribute]
          | DotEmpty
     deriving (Show, Eq)
 
+-- | Dot is a semigroup, duh, that's the point.
+instance Semigroup Dot where
+    -- Left identity
+    (<>) DotEmpty d = d
+
+    -- Right identity
+    (<>) d DotEmpty = d
+
+    -- Associativity
+    (<>) d (DotSeq d1 d2) = DotSeq ((<>) d d1) d2
+
+    (<>) d1 d2 = DotSeq d1 d2
+
 -- | Dot is a monoid, duh, that's the point.
 instance Monoid Dot where
     mempty = DotEmpty
-
-    -- Left identity
-    mappend DotEmpty d = d
-
-    -- Right identity
-    mappend d DotEmpty = d
-
-    -- Associativity
-    mappend d (DotSeq d1 d2) = DotSeq (mappend d d1) d2
-
-    mappend d1 d2 = DotSeq d1 d2
-
-


### PR DESCRIPTION
For compatibility with newer base versions.

Note that I didn't try to keep backward compatibility with older version of base.