### PR TITLE
Bump stack LTS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.0
+resolver: lts-16.26
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Since #6, we need a more recent GHC version.