### PR TITLE
fix text import

### DIFF
--- a/src/Text/Dot/FSA.hs
+++ b/src/Text/Dot/FSA.hs
@@ -9,7 +9,7 @@ import           Text.Dot.Class
 import           Control.Monad  (forM, forM_, when)
 import           Data.Maybe     (fromMaybe, isNothing)
 
-import           Data.Text
+import           Data.Text (Text)
 import qualified Data.Text      as T
 
 -- | An easy way to generate an FSA visualization


### PR DESCRIPTION
Looks like recent text have an `elem` function which conflict with prelude. Explicit import list fixs this.